### PR TITLE
fix: resolve UnhashableParamError in _build_gap_data (#28)

### DIFF
--- a/app.py
+++ b/app.py
@@ -3248,7 +3248,7 @@ st.markdown("<div class='section-title'>Gap to Leader</div>", unsafe_allow_html=
 
 
 @st.cache_data(show_spinner=False, ttl=3600)
-def _build_gap_data(sess_k: str, laps_df: pd.DataFrame, session_obj=None):
+def _build_gap_data(sess_k: str, laps_df: pd.DataFrame, _session_obj=None):
     """Return a dict {driver: pd.Series(gap_seconds, index=lap_number)} for all drivers."""
     try:
         laps = laps_df.copy()
@@ -3278,7 +3278,7 @@ def _build_gap_data(sess_k: str, laps_df: pd.DataFrame, session_obj=None):
             gap_to_leader[drv] = gap
         # Also return track status by lap for shading
         try:
-            ts = session_obj.track_status.copy() if session_obj is not None else None
+            ts = _session_obj.track_status.copy() if _session_obj is not None else None
             if ts is not None:
                 ts["LapNumber"] = ts.index
         except Exception:


### PR DESCRIPTION
## Summary\nRenames `session_obj` → `_session_obj` in `_build_gap_data`'s signature.\n\nStreamlit's `@st.cache_data` tries to hash every argument to produce a cache key. `fastf1.core.Session` is a complex, mutable object that is not hashable, so Streamlit raises `UnhashableParamError`. The fix is straightforward: prefix the parameter with `_` so Streamlit skips it during hash computation.\n\n## Changes\n- `_build_gap_data(sess_k, laps_df, session_obj)` → `_build_gap_data(sess_k, laps_df, _session_obj)`\n- Internal body reference updated accordingly\n\n## Testing\n- `ast.parse` syntax check ✅\n- Cache key is still stable (keyed on `sess_k` + `laps_df`)\n\nCloses #28