### PR TITLE
fix: provide proper Response.raw for FastF1 stream parsing (#32)

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,8 @@ try:
     import requests.adapters
     from curl_cffi import requests as curl_requests
     from requests.structures import CaseInsensitiveDict
+    from urllib3.response import HTTPResponse
+    from io import BytesIO
 
     _F1_DOMAINS = ("formula1.com", "fastf1.dev", "ergast.com")
     _original_adapter_send = requests.adapters.HTTPAdapter.send
@@ -80,6 +82,19 @@ try:
                 resp.encoding = curl_resp.encoding or "utf-8"
                 resp.headers = CaseInsensitiveDict(dict(curl_resp.headers))
                 resp.request = request
+                
+                # FastF1 uses stream=True and iter_lines() on responses like .jsonStream
+                # requests_cache also requires a proper raw response object
+                raw_response = HTTPResponse(
+                    body=BytesIO(curl_resp.content),
+                    headers=curl_resp.headers,
+                    status=curl_resp.status_code,
+                    preload_content=False,
+                    original_response=None
+                )
+                resp.raw = raw_response
+                resp.history = []
+                resp.reason = 'OK'
                 return resp
             except Exception:
                 # Fall back to standard urllib3 if curl_cffi fails


### PR DESCRIPTION
## What changed
Added a properly mocked `urllib3.response.HTTPResponse` to the `requests.Response.raw` attribute in our `HTTPAdapter.send` patch.

## Why the old patch didn't work (again)
While the previous patch successfully routed FastF1 traffic through `curl_cffi` at the `HTTPAdapter` layer, it failed to emulate a full `urllib3` streaming response.
FastF1 heavily relies on parsing `.jsonStream` responses line-by-line using `Response.iter_lines()`, which internally reads from `Response.raw`. Because `.raw` was missing, it caused internal `Traceback` exceptions inside FastF1 during the parsing of `SessionInfo.jsonStream` and `TimingData.jsonStream`. These parsing failures cascaded into the 'No lap timing data is available' error in the app.

## Why the new patch works
By using `io.BytesIO` to wrap the `curl_cffi` response content and passing it into a real `urllib3.response.HTTPResponse`, we perfectly simulate the interface that `requests` and `requests_cache` expect.

## Testing done
- Simulated the exact Streamlit Cloud environment (Python 3.11, FastF1 3.8.1).
- Confirmed the tracebacks no longer occur.
- Successfully loaded the 2024 British GP with 961 laps through the patched adapter.