### PR TITLE
fix: resolve UnhashableParamError by ignoring results_df in cache hashing

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -123,6 +123,7 @@ The official classification results are fetched from `sess.results` and cached u
 - Race/Sprint sessions format absolute time for the winner, relative gaps for subsequent finishers, and DNFs/laps using their status value.
 - Qualifying/Shootout sessions display `Q1`, `Q2`, and `Q3` lap times.
 - Selected drivers in the telemetry selector are highlighted in the classification table with their driver colors.
+- To prevent Streamlit's cache manager from throwing an `UnhashableParamError`, the results DataFrame argument must be prefixed with a leading underscore in the function signature (e.g. `_results_df`), telling Streamlit to skip hashing this complex Pandas subclass object.
 
 
 ---

--- a/DOCS.md
+++ b/DOCS.md
@@ -683,6 +683,9 @@ If you apply a custom CSS keyframe animation to `[data-testid="stSidebar"]` dire
 ### ⑩ Empty Official Standings in Practice Sessions
 Do not assume `sess.results` contains official standings or non-NaN `Position` column entries for practice sessions (`FP1`, `FP2`, `FP3`). They are unordered and `results.Position` is fully null/NaN. For practice sessions, intercept the results check and display an informational note pointing users to the `Fastest Laps Leaderboard` instead of rendering a table of NaNs.
 
+### ⑪ Unhashable Session Results Object in st.cache_data
+FastF1's results DataFrame (`SessionResults`) is a custom pandas DataFrame subclass with extra attributes. Passing it to an `@st.cache_data` cached function throws an `UnhashableParamError` because Streamlit's hash engine doesn't support custom subclassed DataFrames. To fix this, prefix the parameter name in the cached function signature with a leading underscore (e.g., `_results_df`) to exclude it from the hash key calculation.
+
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1535,10 +1535,10 @@ def _format_classification_time(row, is_first=False) -> str:
 
 
 @st.cache_data(show_spinner=False, ttl=3600)
-def _build_final_classification(sess_k: str, results_df: pd.DataFrame):
+def _build_final_classification(sess_k: str, _results_df: pd.DataFrame):
     """Process and return classification results from FastF1."""
     try:
-        df = results_df.copy()
+        df = _results_df.copy()
         if df.empty:
             return None
         


### PR DESCRIPTION
Resolves the UnhashableParamError on results_df in _build_final_classification by prepending a leading underscore to exclude it from Streamlit's hashing process, closing #48.