### PR TITLE
feat: set default selected driver to the race/session winner

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -147,6 +147,13 @@ To give a holistic view of the championship standings alongside session results,
 - Drivers in the session classification DataFrame are mapped to their standing records by checking abbreviation codes (e.g., `NOR`), car/driver number strings, or driver last name substrings.
 - If standings data is not available, the points column gracefully displays `—`.
 
+### 10. Default Selected Driver as Race/Session Winner
+To ensure the dashboard loads displaying the most relevant driver first, the default selected driver is set dynamically to the winner of that session:
+- For Race, Sprint, and Qualifying sessions, the winner is determined by looking up the driver with Position 1 in `session.results`.
+- For Practice sessions, where standings are not defined, the winner is resolved to the driver who set the overall fastest lap in `session.laps`.
+- In cases where the F1 identifier returned by results or laps is a number or alternative key format, a mapping resolver matches it to the respective key in `all_drivers1` (which uses abbreviations or numbers depending on the session data).
+- The default index falls back to Norris ("NOR" / "4") or index 0 if the winner cannot be resolved.
+
 ---
 
 ## Running the Project

--- a/DOCS.md
+++ b/DOCS.md
@@ -695,6 +695,9 @@ Championship standings data is loaded from the external Jolpi (Ergast) API. Beca
 ### ⑭ Multi-Key Matching for Standings Drivers
 Drivers in the standings database (Ergast) may have minor record variations compared to FastF1 results (such as Verstappen's number mapping, name spelling, or temporary replacement drivers). To ensure robust mapping between the session classification results DataFrame and the standings API, resolve drivers using a fallback multi-key matching function check checking driver three-letter abbreviation codes, car number strings, and last/family name substrings before defaulting to a missing value indicator (`—`).
 
+### ⑮ Normalizing Winner Lookup Identifiers
+FastF1 session results and lap telemetry might store driver identifiers as driver numbers (e.g., '4', '1') or abbreviation strings (e.g., 'NOR', 'VER') depending on the session data and year. When resolving the winner to set selectbox default selection indices, always run resolved winners through a mapping resolver checking abbreviation codes and driver numbers against the session's driver labels to translate them safely to the exact key format present in the list of selectbox options.
+
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1534,6 +1534,68 @@ def _format_classification_time(row, is_first=False) -> str:
         return "—"
 
 
+def _map_driver_id_to_number(session, driver_id: str, all_drivers: list) -> str:
+    """Map a driver ID (number or abbreviation) to the key used in all_drivers."""
+    if not driver_id or not all_drivers:
+        return ""
+    
+    driver_id = str(driver_id).strip().upper()
+    if driver_id in all_drivers:
+        return driver_id
+        
+    for key in all_drivers:
+        try:
+            info = session.get_driver(key)
+            abbr = str(info.get("Abbreviation", "")).strip().upper()
+            dnum = str(info.get("DriverNumber", "")).strip().upper()
+            lname = str(info.get("LastName", "")).strip().upper()
+            
+            if driver_id in (abbr, dnum) or (lname and driver_id == lname):
+                return key
+        except Exception:
+            pass
+            
+    return all_drivers[0] if all_drivers else ""
+
+
+def _get_session_winner(session, all_drivers: list) -> str:
+    """Return the driver number/abbreviation string of the session winner / fastest driver."""
+    try:
+        results = session.results
+        if results is not None and not results.empty:
+            if "Position" in results.columns and results["Position"].notna().any():
+                p1_row = results[results["Position"] == 1]
+                if not p1_row.empty:
+                    for col in ["Abbreviation", "DriverNumber", "Driver"]:
+                        if col in p1_row.columns:
+                            val = str(p1_row.iloc[0][col]).strip()
+                            if val in all_drivers:
+                                return val
+                    if "Abbreviation" in p1_row.columns:
+                        abbr = str(p1_row.iloc[0]["Abbreviation"]).strip()
+                        mapped = _map_driver_id_to_number(session, abbr, all_drivers)
+                        if mapped in all_drivers:
+                            return mapped
+                    if "DriverNumber" in p1_row.columns:
+                        dnum = str(p1_row.iloc[0]["DriverNumber"]).strip()
+                        mapped = _map_driver_id_to_number(session, dnum, all_drivers)
+                        if mapped in all_drivers:
+                            return mapped
+                            
+        if hasattr(session, "laps") and session.laps is not None and not session.laps.empty:
+            fastest_lap = session.laps.pick_fastest()
+            if fastest_lap is not None and not pd.isna(fastest_lap.get("Driver")):
+                val = str(fastest_lap["Driver"]).strip()
+                if val in all_drivers:
+                    return val
+                mapped = _map_driver_id_to_number(session, val, all_drivers)
+                if mapped in all_drivers:
+                    return mapped
+    except Exception:
+        pass
+    return "NOR" if "NOR" in all_drivers else (all_drivers[0] if all_drivers else "")
+
+
 def get_constructor_colour(name: str) -> str:
     # Try exact match first
     if name in TEAM_COLOURS:
@@ -2238,7 +2300,8 @@ else:
 st.markdown("<div class='section-title'>Driver Selection</div>", unsafe_allow_html=True)
 col_a, col_b = st.columns([1, 1])
 with col_a:
-    _def_d1_idx = all_drivers1.index("4") if "4" in all_drivers1 else 0
+    _p1_drv1 = _get_session_winner(sess, all_drivers1)
+    _def_d1_idx = all_drivers1.index(_p1_drv1) if _p1_drv1 in all_drivers1 else 0
     driver1 = st.selectbox(
         "Driver 1", all_drivers1, index=_def_d1_idx, key="d1",
         format_func=_fmt_driver1,


### PR DESCRIPTION
Closes #54. Sets the Driver 1 selectbox default selection dynamically to the session winner (Position 1 in session results) or the fastest driver (in practice sessions).