### PR TITLE
feat: show driver name and car number in official classification table (#60)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -159,6 +159,9 @@ To improve user experience, the dashboard initializes both Season 1 and Season 2
 Furthermore, the default Grand Prix index is resolved dynamically by filtering the season's calendar schedule to locate the most recent completed Grand Prix (where the event date is less than or equal to the current system date).
 If no races have occurred yet in the selected season, the dashboard falls back gracefully to the first event of the calendar (Round 1).
 
+### 12. Combined Driver Car Number and Name in Classification Table
+To provide clear mappings between driver numbers and full names, the Driver column in the final session classification table displays both the car number and the formatted name together (e.g., `44 · HAM · Hamilton` instead of just `HAM · Hamilton`). A clean conditional fallback ensures that if full driver information is unavailable, only the car number is displayed.
+
 ---
 
 ## Running the Project

--- a/app.py
+++ b/app.py
@@ -1831,6 +1831,12 @@ def _render_final_classification(df, highlight_drivers: list, highlight_colours:
     
     for i, row in df.iterrows():
         drv = str(row["DriverNumber"])
+        drv_name = fmt_func(drv) if fmt_func else drv
+        if drv_name != drv:
+            display_drv = f"{drv} · {drv_name}"
+        else:
+            display_drv = drv
+            
         is_hl = drv in colour_map
         accent = colour_map.get(drv, "transparent")
         row_bg = f"{accent}18" if is_hl else "transparent"
@@ -1863,7 +1869,7 @@ def _render_final_classification(df, highlight_drivers: list, highlight_colours:
             rows_html += (
                 f"<tr style='background:{row_bg}; {border_css}'>"
                 f"<td style='padding:7px 10px; text-align:center;'>{pos_col}</td>"
-                f"<td style='padding:7px 10px; font-weight:{'600' if is_hl else '400'};'>{fmt_func(drv) if fmt_func else drv}</td>"
+                f"<td style='padding:7px 10px; font-weight:{'600' if is_hl else '400'};'>{display_drv}</td>"
                 f"<td style='padding:7px 10px;'>{team_html}</td>"
                 f"<td style='padding:7px 10px; font-family:monospace; font-size:13px;'>{q1_t}</td>"
                 f"<td style='padding:7px 10px; font-family:monospace; font-size:13px;'>{q2_t}</td>"
@@ -1891,7 +1897,7 @@ def _render_final_classification(df, highlight_drivers: list, highlight_colours:
             rows_html += (
                 f"<tr style='background:{row_bg}; {border_css}'>"
                 f"<td style='padding:7px 10px; text-align:center;'>{pos_col}</td>"
-                f"<td style='padding:7px 10px; font-weight:{'600' if is_hl else '400'};'>{fmt_func(drv) if fmt_func else drv}</td>"
+                f"<td style='padding:7px 10px; font-weight:{'600' if is_hl else '400'};'>{display_drv}</td>"
                 f"<td style='padding:7px 10px;'>{team_html}</td>"
                 f"<td style='padding:7px 10px; text-align:center;'>{grid_str}</td>"
                 f"<td style='padding:7px 10px; font-family:monospace; font-size:13px;'>{time_status}</td>"


### PR DESCRIPTION
This PR resolves Issue #60 by formatting the Driver column in the official session classification table to display both the driver's car number and name/abbreviation together (e.g. 4 · NOR · Norris).