### PR TITLE
fix: resolve classification table missing driver names (#66)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -160,7 +160,7 @@ Furthermore, the default Grand Prix index is resolved dynamically by filtering t
 If no races have occurred yet in the selected season, the dashboard falls back gracefully to the first event of the calendar (Round 1).
 
 ### 12. Combined Driver Car Number and Name in Classification Table
-To provide clear mappings between driver numbers and full names, the Driver column in the final session classification table displays both the car number and the formatted name together (e.g., `44 · HAM · Hamilton` instead of just `HAM · Hamilton`). A clean conditional fallback ensures that if full driver information is unavailable, only the car number is displayed.
+To provide clear mappings between driver numbers and full names, the Driver column in the final session classification table displays both the car number and the formatted name together (e.g., `44 · HAM · Hamilton` instead of just `HAM · Hamilton`). Rather than using selectbox formatting functions (which map from abbreviation strings and cause lookup key mismatches with car numbers), this is resolved directly from the `Abbreviation` and `LastName` columns in the FastF1 results DataFrame. A clean conditional fallback ensures that if driver name info is missing, only the car number is displayed.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1831,9 +1831,13 @@ def _render_final_classification(df, highlight_drivers: list, highlight_colours:
     
     for i, row in df.iterrows():
         drv = str(row["DriverNumber"])
-        drv_name = fmt_func(drv) if fmt_func else drv
-        if drv_name != drv:
-            display_drv = f"{drv} · {drv_name}"
+        abbr = str(row.get("Abbreviation", "")).strip()
+        last_name = str(row.get("LastName", "")).strip()
+        if abbr and abbr != "nan":
+            if last_name and last_name != "nan":
+                display_drv = f"{drv} · {abbr} · {last_name}"
+            else:
+                display_drv = f"{drv} · {abbr}"
         else:
             display_drv = drv
             


### PR DESCRIPTION
This PR fixes a bug where only the driver car numbers were displayed in the official session classification table instead of showing both car numbers and full names. It updates the layout renderer to retrieve abbreviation and lastName columns directly from the results DataFrame, avoiding key mismatches with the selectbox format function.