### PR TITLE
docs: update README documentation for Live Timing Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ The app will install seamlessly onto your device with a custom 🏎 icon, openin
 
 | Problem | Fix |
 |---|---|
-| First load is slow | Expected behavior (FastF1 is downloading ~50-100MB of telemetry). Subsequent loads are cached. |
-| Active / Ongoing Sessions | The dashboard does not support real-time live timing streaming. Active sessions will fail to load until their final static timing data is published on F1's CDN (typically 2–24 hours after completion). |
+| First load is slow | Expected behaviour (FastF1 is downloading ~50-100MB of telemetry). Subsequent loads are cached. |
+| Active / Ongoing Sessions | Toggle **🔴 Real-Time Live Timing Mode** in the sidebar to stream live SignalR WebSocket packets during live sessions. For historical sessions, static timing data is loaded once published on F1's CDN. |
 | Session fails to load | Some recent/future sessions may not be published fully yet. Try an older completed race. |
 | Port 8501 already in use | Run `lsof -i :8501` and kill the process, or run Streamlit on a different port using `streamlit run app.py --server.port 8502` |
 | Docker fails to connect API | The Docker Daemon is not running. Launch the Docker Desktop explicitly first using `open -a Docker`, wait 30 seconds for the engine to initialise, and try again. |


### PR DESCRIPTION
Closes #105. Updates Troubleshooting guidelines in README.md to accurately document Real-Time Live Timing Mode and enforce British English spelling consistency.