### PR TITLE
fix: NameError _drv_labels1 not defined — closure factory for driver labels (#145)

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -129,7 +129,7 @@ sess.load(telemetry=True, laps=True, weather=True, messages=True)
 
 ### Driver Numbers vs Names
 
-FastF1 identifies drivers by **number strings** (`"4"`, `"81"`), not names. Always use numbers as the internal key. Convert to display names only at render time via `_fmt_driver()`.
+FastF1 identifies drivers by **number strings** (`"4"`, `"81"`), not names. Always use numbers as the internal key. Convert to display names only at render time via `_fmt_driver1()` / `_fmt_driver2()`.
 
 
 

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ from src.data.loader import (
     _map_driver_id_to_number, _get_session_winner, _get_default_gp_index,
     get_constructor_colour, is_same_team, _build_constructor_standings,
     get_driver_standings_points, _build_driver_standings, _build_final_classification,
-    _fmt_driver1, _fmt_driver2, _build_lap_history, _build_fuel_adjusted,
+    _make_fmt_driver, _build_lap_history, _build_fuel_adjusted,
     _build_fuel_sim_leaderboard, _build_stints, _build_pit_stops, _build_tyre_deg_data,
     _build_leaderboard, _build_ideal_lap, _build_gap_data, _build_position_data,
     _get_telemetry_for_map, _get_round, start_live_recorder, stop_live_recorder,
@@ -378,6 +378,10 @@ _rc_messages = _build_race_control_messages(sess_key, sess)
 # ── Driver name labels (built once per session) ───────────────────────────────
 _drv_labels1: dict = _build_driver_labels(sess)
 _drv_labels2: dict = _build_driver_labels(sess2) if sess2 is not None else None
+
+# Build closures that capture the labels dicts — avoids NameError from loader.py globals
+_fmt_driver1 = _make_fmt_driver(_drv_labels1)
+_fmt_driver2 = _make_fmt_driver(_drv_labels2 or _drv_labels1, fallback=_drv_labels1)
 
 # ── Export Figures Collection ──────────────────────────────────────────────────
 _export_figs = {}
@@ -2146,7 +2150,7 @@ else:
 
 # ── Multi-Driver Grid Analysis & Heatmaps ───────────────────────────────────────
 st.markdown("<div class='section-title'>Multi-Driver Grid Analysis & Heatmaps</div>", unsafe_allow_html=True)
-_render_grid_heatmap_section(sess, _all_laps1, all_drivers1, sess_key)
+_render_grid_heatmap_section(sess, _all_laps1, all_drivers1, sess_key, fmt_func=_fmt_driver1)
 
 
 

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -738,16 +738,28 @@ def _build_final_classification(sess_k: str, _results_df: pd.DataFrame):
         return None
 
 
-def _fmt_driver1(num: str) -> str:
-    """Format function for selectbox — shows 'ABR · Last Name' for Session 1."""
-    return _drv_labels1.get(str(num), str(num))
+def _make_fmt_driver(drv_labels: dict, fallback: dict | None = None):
+    """Return a format_func closure for st.selectbox that shows 'ABR · Last Name'.
 
+    Args:
+        drv_labels: Primary labels dict built by _build_driver_labels for the session.
+        fallback:   Optional fallback dict (e.g. Session 1 labels when Session 2 is
+                    missing a driver). Consulted only when drv_labels has no match.
 
-def _fmt_driver2(num: str) -> str:
-    """Format function for selectbox — shows 'ABR · Last Name' for Session 2."""
-    if _drv_labels2 is not None:
-        return _drv_labels2.get(str(num), str(num))
-    return _drv_labels1.get(str(num), str(num))
+    Usage in app.py::
+
+        _fmt_driver1 = _make_fmt_driver(_drv_labels1)
+        _fmt_driver2 = _make_fmt_driver(_drv_labels2 or _drv_labels1, fallback=_drv_labels1)
+    """
+    def _fmt(num: str) -> str:
+        key = str(num)
+        label = drv_labels.get(key)
+        if label is not None:
+            return label
+        if fallback is not None:
+            return fallback.get(key, key)
+        return key
+    return _fmt
 
 
 def _build_lap_history(driver: str, sess_k: str, laps_df: pd.DataFrame):

--- a/src/ui/components.py
+++ b/src/ui/components.py
@@ -9,7 +9,7 @@ from src.data.loader import (
     _get_session_winner, _get_default_gp_index, get_constructor_colour,
     is_same_team, _build_constructor_standings, get_driver_standings_points,
     _build_driver_standings, _build_final_classification, _get_telemetry_for_map,
-    _fmt_driver1, _fmt_driver2, _build_grid_heatmap_data, _build_consistency_analysis,
+    _build_grid_heatmap_data, _build_consistency_analysis,
     _build_weather_correlation_data, _build_multi_year_comparison
 )
 from src.charts.plotly import (
@@ -1118,7 +1118,7 @@ def render_maps_block(session, session_obj, sess_k, driver, other_driver, colour
             st.info("Load a session to view corner analysis.")
 
 
-def _render_grid_heatmap_section(sess, laps_df: pd.DataFrame, all_drivers: list[str], sess_key: str):
+def _render_grid_heatmap_section(sess, laps_df: pd.DataFrame, all_drivers: list[str], sess_key: str, fmt_func=None):
     """Render the Multi-Driver Grid Analysis & Heatmaps section in app.py."""
     if sess is None or laps_df is None or laps_df.empty or not all_drivers:
         st.info("ℹ️ Multi-driver grid analysis is unavailable for this session.")
@@ -1133,7 +1133,7 @@ def _render_grid_heatmap_section(sess, laps_df: pd.DataFrame, all_drivers: list[
             options=all_drivers,
             default=default_drvs,
             key="grid_heatmap_drivers_select",
-            format_func=_fmt_driver1,
+            format_func=fmt_func if fmt_func is not None else str,
             help="Select drivers across the grid to compare split times, pace deltas, and top speeds.",
         )
 


### PR DESCRIPTION
## Bug Fix

Resolves #145 — `NameError: name '_drv_labels1' is not defined` on cold app load.

## Root Cause

`_fmt_driver1` / `_fmt_driver2` in `src/data/loader.py` referenced `_drv_labels1` / `_drv_labels2` as bare module-level globals. Those names are assigned in `app.py`'s namespace — not `loader.py`'s. Python resolves globals at **call time** using the *defining* module's namespace, so the lookup always failed with `NameError`.

## Fix

### `src/data/loader.py`
- Removed `_fmt_driver1` / `_fmt_driver2` (bare global-referencing functions)
- Added `_make_fmt_driver(drv_labels, fallback=None)` — a closure factory that captures the labels dict at call time

### `app.py`
- Imports `_make_fmt_driver` (replaces the removed functions)
- Builds `_fmt_driver1` / `_fmt_driver2` as local closures immediately after `_drv_labels1` / `_drv_labels2` are assigned
- Passes `fmt_func=_fmt_driver1` to `_render_grid_heatmap_section`

### `src/ui/components.py`
- Removed stale `_fmt_driver1` / `_fmt_driver2` import from loader
- Added `fmt_func=None` parameter to `_render_grid_heatmap_section`; defaults to `str` if not supplied

### `DOCS.md`
- Fixed stale `_fmt_driver()` reference in Section 4 → `_fmt_driver1()` / `_fmt_driver2()`

## Test Results
- 34/34 tests pass
- All 6 modules compile clean